### PR TITLE
Add socket error handling

### DIFF
--- a/lib/src/database/cursor.dart
+++ b/lib/src/database/cursor.dart
@@ -109,6 +109,9 @@ class Cursor {
         eachCallback(val);
         _nextEach();
       }
+    }).catchError((e) {
+      eachCallback = null;
+      eachComplete.completeError(e);
     });
   }
   
@@ -133,13 +136,15 @@ class Cursor {
     if (cursorId != 0){
       MongoKillCursorsMessage msg = new MongoKillCursorsMessage(cursorId);
       cursorId = 0;
-      db.queryMessage(msg);
+      db.queryMessage(msg).catchError((e) => null);
     }
     return new Future.value(null);
   }
   
   Stream<Map> get stream {
-    forEach(controller.add).then((_) => controller.close());
+    forEach(controller.add)
+      .catchError((e) => controller.addError(e))
+      .then((_) => controller.close());
     return controller.stream; 
   }
 }

--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -203,7 +203,7 @@ class Db {
       } else {
         result.completeError(replyMessage.documents[0]);
       }
-    });
+    }).catchError((e) => result.completeError(e));
     return result.future;
   }
   

--- a/lib/src/database/dbcollection.dart
+++ b/lib/src/database/dbcollection.dart
@@ -26,24 +26,28 @@ class DbCollection {
   }
   
   Future insertAll(List<Map> documents, {WriteConcern writeConcern}) {
-    MongoInsertMessage insertMessage = new MongoInsertMessage(fullName(),documents);
-    db.executeMessage(insertMessage, writeConcern);
-    return db._getAcknowledgement(writeConcern: writeConcern);
+    return new Future.sync(() {
+      MongoInsertMessage insertMessage = new MongoInsertMessage(fullName(),documents);
+      db.executeMessage(insertMessage, writeConcern);
+      return db._getAcknowledgement(writeConcern: writeConcern);
+    });
   }
   
   Future update(selector, document, {bool upsert: false, bool multiUpdate: false, WriteConcern writeConcern}) {
-    int flags = 0;
-    if (upsert) {
-      flags |= 0x1;
-    }
-    if (multiUpdate) {
-      flags |= 0x2;
-    }
+    return new Future.sync(() {
+      int flags = 0;
+      if (upsert) {
+        flags |= 0x1;
+      }
+      if (multiUpdate) {
+        flags |= 0x2;
+      }
 
-    MongoUpdateMessage message = new MongoUpdateMessage(fullName(), 
-        _selectorBuilder2Map(selector), document, flags);
-    db.executeMessage(message, writeConcern);
-    return db._getAcknowledgement(writeConcern: writeConcern);
+      MongoUpdateMessage message = new MongoUpdateMessage(fullName(), 
+          _selectorBuilder2Map(selector), document, flags);
+      db.executeMessage(message, writeConcern);
+      return db._getAcknowledgement(writeConcern: writeConcern);
+    });
   }
 
   /**

--- a/lib/src/network/connection.dart
+++ b/lib/src/network/connection.dart
@@ -5,11 +5,12 @@ class _Connection {
   _ConnectionManager _manager;
   ServerConfig serverConfig;
   Socket socket;
+  Set<int> _pendingQueries = new Set();
   get _replyCompleters => _manager.replyCompleters;
   get _sendQueue => _manager.sendQueue;
   StreamSubscription<List<int>> _socketSubscription;
   bool connected = false;
-  bool _closing = false;
+  bool _closed = false;
   bool isMaster = false;
   
   _Connection(this._manager, [this.serverConfig]) {
@@ -27,7 +28,12 @@ class _Connection {
         .transform(new MongoMessageHandler().transformer)
         .listen(_receiveReply,onError: (e) {
         print("Socket error ${e}");
-        completer.completeError(e);
+
+        //completer.completeError(e);
+      }, onDone: () {
+        if (!_closed) {
+          _onSocketError();
+        }
       });
       connected = true;
       completer.complete(true);
@@ -38,7 +44,7 @@ class _Connection {
   }
 
   Future close() {
-    _closing = true;
+    _closed = true;
     return socket.close();
   }
   
@@ -54,10 +60,15 @@ class _Connection {
   
   Future<MongoReplyMessage> query(MongoMessage queryMessage) {
     Completer completer = new Completer();
-    _replyCompleters[queryMessage.requestId] = completer;
-    _log.fine('Query $queryMessage');
-    _sendQueue.addLast(queryMessage);
-    _sendBuffer();
+    if (!_closed) {
+      _replyCompleters[queryMessage.requestId] = completer;
+      _pendingQueries.add(queryMessage.requestId);
+      _log.fine('Query $queryMessage');
+      _sendQueue.addLast(queryMessage);
+      _sendBuffer();
+    } else {
+      completer.completeError(const ConnectionException("Invalid state: Connection already closed."));
+    }
     return completer.future;
   }
 
@@ -67,6 +78,9 @@ class _Connection {
   ///   be sent 'together')
 
   void execute(MongoMessage mongoMessage, bool runImmediately) {
+    if (_closed) {
+      throw const ConnectionException("Invalid state: Connection already closed.");
+    }
     _log.fine('Execute $mongoMessage');
     _sendQueue.addLast(mongoMessage);
     if (runImmediately) {
@@ -77,13 +91,34 @@ class _Connection {
   void _receiveReply(MongoReplyMessage reply) {
     _log.fine(reply.toString());
     Completer completer = _replyCompleters.remove(reply.responseTo);
+    _pendingQueries.remove(reply.responseTo);
     if (completer != null){
       _log.fine('Completing $reply');
       completer.complete(reply);
     } else {
-      if (!_closing) {
+      if (!_closed) {
         _log.info("Unexpected respondTo: ${reply.responseTo} $reply");
       }
     }
   }
+
+  void _onSocketError() {
+    _closed = true;
+    var ex = const ConnectionException("connection closed.");
+    _pendingQueries.forEach((id) {
+      Completer completer = _replyCompleters.remove(reply.responseTo);
+      completer.completeError(ex);
+    });
+    _pendingQueries.clear();
+  }
+}
+
+class ConnectionException implements Exception {
+
+  final String message;
+
+  const ConnectionException([String this.message = ""]);
+
+  String toString() => "MongoDB ConnectionException: $message";
+
 }

--- a/test/database_tests.dart
+++ b/test/database_tests.dart
@@ -956,6 +956,34 @@ Future testFieldLevelUpdateSimple() {
   });
 }
 
+Future testQueryOnClosedConnection() {
+  Db db = new Db('${DefaultUri}mongo_dart-test');
+  return db.open().then((c) {
+    return db.close().then((_) {
+      return db.collection("test").find().toList().catchError((e) {
+        expect(e is ConnectionException, isTrue);
+        return "error_received";
+      }).then((msg) {
+        expect(msg, equals("error_received"));
+      });
+    });
+  });
+}
+
+Future testUpdateOnClosedConnection() {
+  Db db = new Db('${DefaultUri}mongo_dart-test');
+  return db.open().then((c) {
+    return db.close().then((_) {
+      return db.collection("test").save({"test": "test"}).catchError((e) {
+        expect(e is ConnectionException, isTrue);
+        return "error_received";
+      }).then((msg) {
+        expect(msg, equals("error_received"));
+      });
+    });
+  });
+}
+
 
 main(){
 //  hierarchicalLoggingEnabled = true;
@@ -1038,5 +1066,9 @@ main(){
     test('testFieldLevelUpdateSimple',testFieldLevelUpdateSimple);
   });
 
+  group('Socket error handling:', () {
+    test('testQueryOnClosedConnection', testQueryOnClosedConnection);
+    test("testUpdateOnClosedConnection", testUpdateOnClosedConnection);
+  });
 
 }


### PR DESCRIPTION
Hi,

This is a simple patch to allow better error handling when a connection with the database is lost.

In the current version, if a connection is lost and the user sends a query to the database, a error is thrown in the zone where the connection was open, not in the zone where the user sent the query, which makes the process of handling errors more difficult, especially when you need to reuse connections.

With this patch, if the connection is lost, the driver will notify any pending request associated with the connection. If another request is received, it will answer the request with an error, instead of trying to write the message to the socket.
