### PR TITLE
Remove validation for index keys

### DIFF
--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -335,11 +335,7 @@ class Db {
       selector['ns'] = '$databaseName.$collectionName';
       keys = _setKeys(key, keys);
       selector['key'] = keys;
-      for (final order in keys.values) {
-        if (order != 1 && order != -1) {
-          throw new ArgumentError('Keys may contain only 1 or -1');
-        }
-      }
+
       if (unique == true) {
         selector['unique'] = true;
       } else {


### PR DESCRIPTION
Currently, when creating an index with `createIndex()` or `ensureIndex()`, mongo_dart doesn't accept key values different than 1 or -1. Although, MongoDB also accepts string values, such as "text" or "2dsphere". Considering the value is validated by MongoDB itself, I think it's safe to remove this validation from mongo_dart. 
