### PR TITLE
Fix bad type in _Connection class

### DIFF
--- a/lib/src/network/connection.dart
+++ b/lib/src/network/connection.dart
@@ -35,8 +35,8 @@ class _Connection {
   Set<int> _pendingQueries = new Set();
   get _replyCompleters => _manager.replyCompleters;
   get _sendQueue => _manager.sendQueue;
-  StreamSubscription<List<int>> _socketSubscription;
-  StreamSubscription<List<int>> get socketSubscription => _socketSubscription;
+  StreamSubscription<MongoReplyMessage> _socketSubscription;
+  StreamSubscription<MongoReplyMessage> get socketSubscription => _socketSubscription;
 
   bool connected = false;
   bool _closed = false;


### PR DESCRIPTION
Since the SocketSubscription is transformed by the `MongoMessageHandler` it is of type `StreamSubscription<MongoReplyMessage>` and not `StreamSubscription<List<int>>`.
The class `_Connection` is private and does not implement any public interface. As such, it is unlikely that fixing the type would break users.

Fwiw, I couldn't find any user of `socketSubscription` in the repository (but I only used github's search, and I am not very familiar with it).

Note: it might be interesting to rename the field, since it's not just a socketSubscription, but a transformed subscription.