### PR TITLE
Added PartialFilterExpression on createIndex

### DIFF
--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -472,6 +472,7 @@ class Db {
       bool sparse,
       bool background,
       bool dropDups,
+      Map partialFilterExpression,
       String name}) {
     return new Future.sync(() async {
       var selector = {};
@@ -492,6 +493,9 @@ class Db {
       }
       if (dropDups == true) {
         selector['dropDups'] = true;
+      }
+      if (partialFilterExpression != null) {
+        selector['partialFilterExpression'] = partialFilterExpression;
       }
       if (name == null) {
         name = _createIndexName(keys);
@@ -528,6 +532,7 @@ class Db {
       bool sparse,
       bool background,
       bool dropDups,
+      Map partialFilterExpression,
       String name}) async {
     keys = _setKeys(key, keys);
     var indexInfos = await collection(collectionName).getIndexes();
@@ -546,6 +551,7 @@ class Db {
         sparse: sparse,
         background: background,
         dropDups: dropDups,
+        partialFilterExpression: partialFilterExpression,
         name: name);
 
     return createdIndex;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mongo_dart
-version: 0.2.10
+version: 0.2.10+1
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
 - Ted Sander <ted@tedsander.com>

--- a/test/database_test.dart
+++ b/test/database_test.dart
@@ -800,8 +800,15 @@ Future testIndexCreation() async {
   res = await db.createIndex(collectionName, keys: {'a': -1, 'embedded.c': 1});
   expect(res['ok'], 1.0);
 
+  res = await db.createIndex(collectionName, keys: {
+    'a': -1
+  }, partialFilterExpression: {
+    "embedded.c": {r"$exists": true}
+  });
+  expect(res['ok'], 1.0);
+
   var indexes = await collection.getIndexes();
-  expect(indexes.length, 3);
+  expect(indexes.length, 4);
 
   res = await db.ensureIndex(collectionName, keys: {'a': -1, 'embedded.c': 1});
   expect(res['ok'], 1.0);


### PR DESCRIPTION
In MongoDb 3.2 it was added a new index type that allows to specify a selection criteria of the documents included into the index. It is, in some way, an improvement over the sparse index.
I have added a new parameter allowing the usert to add the filter expression on the `createIndex `and `ensureIndex` methods.