### PR TITLE
Updated for Dart 2

### DIFF
--- a/lib/mongo_dart.dart
+++ b/lib/mongo_dart.dart
@@ -6,13 +6,12 @@ library mongo_dart;
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:io' hide FileMode;
+import 'dart:convert' show base64, utf8;
+import 'dart:io' show File, FileMode, IOSink, Socket;
 import 'dart:math';
 import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' as crypto;
-import 'package:dart2_constant/convert.dart';
-import 'package:dart2_constant/io.dart';
 import 'package:bson/bson.dart';
 import 'package:logging/logging.dart';
 import 'package:mongo_dart_query/mongo_dart_query.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mongo_dart
-version: 0.3.2
+version: 0.3.3
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
 - Ted Sander <ted@tedsander.com>
@@ -9,16 +9,16 @@ authors:
 description: MongoDB driver for Dart
 homepage: https://github.com/mongo-dart/mongo_dart
 environment:
-  sdk: '>=1.10.0<2.0.0'
+  sdk: '>=2.0.0-dev.69.3 <3.0.0'
 dependencies:
-  bson: '^0.3.0'
-  crypto: '>=0.9.2 <3.0.0'
-  dart2_constant: '^1.0.0'
-  logging: '>=0.8.0 <2.0.0'
-  mongo_dart_query: '^0.3.0'
-  collection: ">=1.4.0 <2.0.0"
-  path: ">=1.3.0 <2.0.0"
-  pool: ">=1.0.0 <2.0.0"
-  uuid: "^0.5.0"
+  bson: '^0.3.2'
+  crypto: '^2.0.6'
+  logging: '^0.11.3+2'
+  mongo_dart_query:
+    git: 'https://github.com/jbaxe2/mongo_dart_query.git'
+  collection: '^1.14.11'
+  path: '^1.6.2'
+  pool: '^1.3.6'
+  uuid: '^1.0.1'
 dev_dependencies:
-  test: ">=0.12.0"
+  test: '^1.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   bson: '^0.3.2'
   crypto: '^2.0.6'
   logging: '^0.11.3+2'
-  mongo_dart_query:
-    git: 'https://github.com/jbaxe2/mongo_dart_query.git'
+  mongo_dart_query: '^0.3.2'
   collection: '^1.14.11'
   path: '^1.6.2'
   pool: '^1.3.6'

--- a/test/authentication_test.dart
+++ b/test/authentication_test.dart
@@ -48,7 +48,7 @@ main() {
       (err['codeName'] == expectedError['codeName'])
     );
 
-    expect (result, true);
+    expect(result, true);
   });
 
   test("Throw exception when auth mechanism isn't supported", () async {

--- a/test/authentication_test.dart
+++ b/test/authentication_test.dart
@@ -25,6 +25,7 @@ main() {
 
   test("Can't connect with mongodb-cr on a db without that scheme", () async {
     Db db = new Db('$mongoDbUri/?authMechanism=${MongoDbCRAuthenticator.name}');
+
     var expectedError = {
       'ok': 0.0,
       'errmsg': 'auth failed',
@@ -32,9 +33,22 @@ main() {
       'codeName': 'AuthenticationFailed',
     };
 
-    var sut = () async => await db.open();
+    var err;
 
-    expect(sut(), throwsA(expectedError));
+    try {
+      await db.open();
+    } catch (e) {
+      err = e;
+    }
+
+    bool result = (
+      (err['ok'] == expectedError['ok']) &&
+      (err['errmsg'] == expectedError['errmsg']) &&
+      (err['code'] == expectedError['code']) &&
+      (err['codeName'] == expectedError['codeName'])
+    );
+
+    expect (result, true);
   });
 
   test("Throw exception when auth mechanism isn't supported", () async {

--- a/test/mongo_actions.dart
+++ b/test/mongo_actions.dart
@@ -1,7 +1,7 @@
 library mongo_actions;
 
+import 'dart:convert' show utf8;
 import 'dart:io';
-import 'package:dart2_constant/convert.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 


### PR DESCRIPTION
Updated SDK and dependencies for Dart 2.  Updated an auth test (MongoDB seems to be passing back extra info [including cluster and operation timestamps, and signature hash] that caused the test to fail), to validate against the expected error.  Incremented version from 0.3.2 to 0.3.3.