### PR TITLE
* Dart/Flutter 1.9 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 #Recent change notes
 
+### 0.4.0
+* Dart/Flutter 1.9 compatibility
+
 ### 0.3.4
 * Added `cursor` option to `DbCollection.aggregate`.
   * Courtesy of @jodinathan, thank you!

--- a/lib/src/network/mongo_message_transformer.dart
+++ b/lib/src/network/mongo_message_transformer.dart
@@ -4,7 +4,7 @@ class MongoMessageHandler {
   final _log = Logger('MongoMessageTransformer');
   final converter = PacketConverter();
 
-  void handleData(List<int> data, EventSink<MongoReplyMessage> sink) {
+  void handleData(Uint8List data, EventSink<MongoReplyMessage> sink) {
     converter.addPacket(data);
     while (!converter.messages.isEmpty) {
       var buffer = BsonBinary.from(converter.messages.removeFirst());
@@ -23,7 +23,7 @@ class MongoMessageHandler {
     sink.close();
   }
 
-  StreamTransformer<List<int>, MongoReplyMessage> get transformer =>
-      StreamTransformer<List<int>, MongoReplyMessage>.fromHandlers(
+  StreamTransformer<Uint8List, MongoReplyMessage> get transformer =>
+      StreamTransformer<Uint8List, MongoReplyMessage>.fromHandlers(
           handleData: handleData, handleDone: handleDone);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mongo_dart
-version: 0.3.4
+version: 0.4.0
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
 - Ted Sander <ted@tedsander.com>

--- a/test/packet_converter_test.dart
+++ b/test/packet_converter_test.dart
@@ -121,5 +121,5 @@ main() {
 }
 
 Uint8List toUint8List(List<int> list) {
-  return Uint8List(list.length)..addAll(list);
+  return Uint8List.fromList(list);
 }


### PR DESCRIPTION
Since updating to Flutter 1.9 /Dart 2.5 mongo_dart does not work due to change in List<int> to Uint8List. Pull request fixes this