### PR TITLE
Fixed analyzer warnings, SDK 2.16.2

### DIFF
--- a/example/updates.dart
+++ b/example/updates.dart
@@ -21,7 +21,8 @@ void main() async {
   }
   print('Record c: $v1');
   v1['value'] = 31;
-  await coll.save(v1);
+  //await coll.save(v1);
+  await coll.insertOne(v1);
   var v2 = await coll.findOne({'name': 'c'});
   print('Record c after update: $v2');
 

--- a/lib/mongo_dart.dart
+++ b/lib/mongo_dart.dart
@@ -32,9 +32,6 @@ import 'package:mongo_dart/src/database/commands/aggreagation_commands/distinct/
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_operation.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_options.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_options.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_statement.dart';
 import 'package:mongo_dart/src/database/commands/operation.dart';
 import 'package:mongo_dart/src/database/utils/dns_lookup.dart';
 import 'package:mongo_dart/src/database/utils/map_keys.dart';

--- a/lib/src/database/commands/administration_commands/create_command/create_options.dart
+++ b/lib/src/database/commands/administration_commands/create_command/create_options.dart
@@ -1,6 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 /// Create command options;
 ///

--- a/lib/src/database/commands/administration_commands/create_index_operation/create_index_options.dart
+++ b/lib/src/database/commands/administration_commands/create_index_operation/create_index_options.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 /// @param {object} [options] Optional settings.
 /// @param {(number|string)} [options.writeConcern] The write concern.

--- a/lib/src/database/commands/administration_commands/get_all_parameters_command/get_all_parameters_command.dart
+++ b/lib/src/database/commands/administration_commands/get_all_parameters_command/get_all_parameters_command.dart
@@ -1,7 +1,6 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/base/db_admin_command_operation.dart';
 import 'get_all_parameters_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class GetAllParametersCommand extends DbAdminCommandOperation {
   GetAllParametersCommand(Db db,

--- a/lib/src/database/commands/administration_commands/get_parameter_command/get_parameter_command.dart
+++ b/lib/src/database/commands/administration_commands/get_parameter_command/get_parameter_command.dart
@@ -1,7 +1,6 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/base/db_admin_command_operation.dart';
 import 'get_parameter_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class GetParameterCommand extends DbAdminCommandOperation {
   GetParameterCommand(Db db, String parameterName,

--- a/lib/src/database/commands/administration_commands/wrapper/create_collection/create_collection_options.dart
+++ b/lib/src/database/commands/administration_commands/wrapper/create_collection/create_collection_options.dart
@@ -1,6 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/administration_commands/create_command/create_options.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 
 class CreateCollectionOptions extends CreateOptions {
   CreateCollectionOptions({
@@ -19,6 +18,8 @@ class CreateCollectionOptions extends CreateOptions {
   }) : super(
             capped: capped,
             size: size,
+            // keeping here for backward compatabilit with 3.2
+            // ignore: deprecated_member_use_from_same_package
             autoIndexId: autoIndexId,
             max: max,
             storageEngine: storageEngine,

--- a/lib/src/database/commands/aggreagation_commands/aggregate/aggregate_options.dart
+++ b/lib/src/database/commands/aggreagation_commands/aggregate/aggregate_options.dart
@@ -1,7 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/commands/parameters/read_concern.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class AggregateOptions {
   /// Enables writing to temporary files. When set to true, a

--- a/lib/src/database/commands/aggreagation_commands/count/count_options.dart
+++ b/lib/src/database/commands/aggreagation_commands/count/count_options.dart
@@ -1,7 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/commands/parameters/read_concern.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class CountOptions {
   /// Starting in MongoDB 3.6, the readConcern option has the following syntax:

--- a/lib/src/database/commands/aggreagation_commands/distinct/distinct_options.dart
+++ b/lib/src/database/commands/aggreagation_commands/distinct/distinct_options.dart
@@ -1,7 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/commands/parameters/read_concern.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class DistinctOptions {
   /// Starting in MongoDB 3.6, the readConcern option has the following syntax:

--- a/lib/src/database/commands/aggreagation_commands/wrapper/change_stream/change_stream_options.dart
+++ b/lib/src/database/commands/aggreagation_commands/wrapper/change_stream/change_stream_options.dart
@@ -1,7 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/aggreagation_commands/aggregate/aggregate_options.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 /// Parameters for the ChangeStream Operation
 ///

--- a/lib/src/database/commands/authentication_commands/sasl_continue_command/sasl_continue_command.dart
+++ b/lib/src/database/commands/authentication_commands/sasl_continue_command/sasl_continue_command.dart
@@ -6,7 +6,6 @@ import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
 import 'package:mongo_dart/src/database/message/additional/section.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
 import 'sasl_continue_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class SaslContinueCommand extends CommandOperation {
   SaslContinueCommand(Db db, int conversationId, Uint8List payload,

--- a/lib/src/database/commands/authentication_commands/sasl_start_command/sasl_start_command.dart
+++ b/lib/src/database/commands/authentication_commands/sasl_start_command/sasl_start_command.dart
@@ -5,8 +5,6 @@ import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
 import 'package:mongo_dart/src/database/message/additional/section.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
-import 'sasl_start_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class SaslStartCommand extends CommandOperation {
   SaslStartCommand(Db db, String mechanism, Uint8List payload,

--- a/lib/src/database/commands/base/cursor_result.dart
+++ b/lib/src/database/commands/base/cursor_result.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:mongo_dart/src/database/utils/mongo_db_namespace.dart';
 
 /// Contains the cursor information,

--- a/lib/src/database/commands/base/operation_base.dart
+++ b/lib/src/database/commands/base/operation_base.dart
@@ -1,5 +1,3 @@
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
-
 import '../../../../mongo_dart.dart';
 
 enum Aspect {

--- a/lib/src/database/commands/diagnostic_commands/server_status_command/server_status_command.dart
+++ b/lib/src/database/commands/diagnostic_commands/server_status_command/server_status_command.dart
@@ -1,8 +1,6 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
-import 'server_status_options.dart';
 import 'server_status_result.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 var _command = <String, Object>{keyServerStatus: 1};
 

--- a/lib/src/database/commands/parameters/collation_options.dart
+++ b/lib/src/database/commands/parameters/collation_options.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 List<String> _caseFirstValidValues = <String>['upper', 'lower', 'off'];
 List<String> _alternateValidValues = <String>['non-ignorable', 'shifted'];

--- a/lib/src/database/commands/query_and_write_operation_commands/delete_operation/delete_statement.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/delete_operation/delete_statement.dart
@@ -1,6 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class DeleteStatement {
   DeleteStatement(this.filter,

--- a/lib/src/database/commands/query_and_write_operation_commands/find_and_modify_operation/find_and_modify_options.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/find_and_modify_operation/find_and_modify_options.dart
@@ -1,6 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class FindAndModifyOptions {
   /// Enables findAndModify to bypass document validation during the operation.

--- a/lib/src/database/commands/query_and_write_operation_commands/find_operation/find_options.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/find_operation/find_options.dart
@@ -1,7 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/commands/parameters/read_concern.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class FindOptions {
   /// The number of documents to return in the first batch. Defaults to **101**.

--- a/lib/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_options.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_options.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 /// GetMore command options;
 ///

--- a/lib/src/database/commands/query_and_write_operation_commands/update_operation/update_options.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/update_operation/update_options.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class UpdateOptions {
   /// A document expressing the [write concern](https://docs.mongodb.com/manual/reference/write-concern/).

--- a/lib/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart
@@ -1,6 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class UpdateStatement {
   UpdateStatement(this.q, this.u,

--- a/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/bulk.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/bulk.dart
@@ -4,22 +4,6 @@ import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
 import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
 import 'package:mongo_dart/src/database/commands/base/operation_base.dart';
-import 'package:mongo_dart/src/database/commands/operation.dart'
-    show
-        BulkWriteResult,
-        CollationOptions,
-        DeleteManyOperation,
-        DeleteManyStatement,
-        DeleteOneOperation,
-        DeleteOneStatement,
-        InsertManyOperation,
-        InsertOneOperation,
-        ReplaceOneOperation,
-        ReplaceOneStatement,
-        UpdateManyOperation,
-        UpdateManyStatement,
-        UpdateOneOperation,
-        UpdateOneStatement;
 
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/return_classes/abstract_write_result.dart';
 

--- a/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/ordered_bulk.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/ordered_bulk.dart
@@ -1,7 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
-
-import 'bulk.dart';
 import 'bulk_options.dart';
 
 class OrderedBulk extends Bulk {

--- a/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/unordered_bulk.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/wrapper/bulk/unordered_bulk.dart
@@ -1,7 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
-
-import 'bulk.dart';
 import 'bulk_options.dart';
 
 class UnorderedBulk extends Bulk {

--- a/lib/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_statement.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_statement.dart
@@ -1,6 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/utils/update_document_check.dart';
 
 class ReplaceOneStatement extends UpdateStatement {

--- a/lib/src/database/commands/query_and_write_operation_commands/wrapper/update_one/update_one_statement.dart
+++ b/lib/src/database/commands/query_and_write_operation_commands/wrapper/update_one/update_one_statement.dart
@@ -1,6 +1,5 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
 import 'package:mongo_dart/src/database/utils/update_document_check.dart';
 
 class UpdateOneStatement extends UpdateStatement {

--- a/lib/src/database/commands/replication_commands/hello_command/hello_command.dart
+++ b/lib/src/database/commands/replication_commands/hello_command/hello_command.dart
@@ -3,9 +3,6 @@ import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
 import 'package:mongo_dart/src/database/message/additional/section.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
 import 'package:vy_string_utils/vy_string_utils.dart';
-import 'hello_options.dart';
-import 'hello_result.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 var _command = <String, Object>{keyHello: 1};
 

--- a/lib/src/database/cursor/cursor.dart
+++ b/lib/src/database/cursor/cursor.dart
@@ -3,7 +3,6 @@ part of mongo_dart;
 typedef MonadicBlock = void Function(Map<String, dynamic> value);
 
 class Cursor {
-  final _log = Logger('Cursor');
   State state = State.INIT;
   int cursorId = 0;
   Db db;
@@ -138,7 +137,7 @@ class Cursor {
         } else if (tailable && !isDead) {
           var completer = Completer<Map<String, dynamic>>();
           Timer(Duration(milliseconds: tailableRetryInterval),
-              () => completer.complete(null));
+              () => completer.complete({}));
           return completer.future;
         } else {
           state = State.CLOSED;

--- a/lib/src/database/cursor/modern_cursor.dart
+++ b/lib/src/database/cursor/modern_cursor.dart
@@ -2,17 +2,12 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'package:bson/bson.dart' show BsonLong;
-
 import 'package:mongo_dart/src/database/commands/base/command_operation.dart';
 import 'package:mongo_dart/src/database/commands/administration_commands/kill_cursors_command/kill_cursors_command.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/aggregate/return_classes/change_event.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/wrapper/change_stream/change_stream_handler.dart';
-import 'package:mongo_dart/src/database/commands/aggreagation_commands/wrapper/change_stream/change_stream_operation.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_command.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_operation.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 import '../../../mongo_dart.dart';
 

--- a/lib/src/database/utils/mongo_db_namespace.dart
+++ b/lib/src/database/utils/mongo_db_namespace.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 
 class MongoDBNamespace {
   final String db;

--- a/lib/src/database/utils/parms_utils.dart
+++ b/lib/src/database/utils/parms_utils.dart
@@ -1,6 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
-import 'package:mongo_dart_query/mongo_dart_query.dart';
 
 Map<String, dynamic> extractfilterMap(filter) {
   if (filter == null) {

--- a/lib/src/network/packet_converter.dart
+++ b/lib/src/network/packet_converter.dart
@@ -1,7 +1,6 @@
 part of mongo_dart;
 
 class PacketConverter {
-  final _log = Logger('PacketConverter');
   final packets = ListQueue<List<int>>();
   final messages = ListQueue<List<int>>();
   final MAX_DOC_SIZE = 32 * 1024 * 1024;

--- a/test/authentication_test.dart
+++ b/test/authentication_test.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:sasl_scram/sasl_scram.dart' show CryptoStrengthStringGenerator;
 import 'package:test/test.dart';
 

--- a/test/database_test.dart
+++ b/test/database_test.dart
@@ -4,11 +4,8 @@ library database_tests;
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:mongo_dart/src/database/cursor/modern_cursor.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_operation.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'dart:async';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 const dbName = 'test-mongo-dart';
 const dbAddress = '127.0.0.1';
@@ -221,7 +218,6 @@ Future testDateTime() async {
       .find(where.lt('posted_on', DateTime.utc(2013, 1, 5)))
       .toList();
 
-  expect(result is List, isTrue);
   expect(result.length, 4);
 }
 

--- a/test/decimal_test.dart
+++ b/test/decimal_test.dart
@@ -3,7 +3,6 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:rational/rational.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 const dbName = 'test';
 const dbAddress = '127.0.0.1';

--- a/test/gridfs_test.dart
+++ b/test/gridfs_test.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'dart:async';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
-import 'package:uuid/uuid.dart';
 
 const dbName = 'testauth';
 const DefaultUri = 'mongodb://localhost:27017/test-mongo-dart';

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -4,7 +4,6 @@ import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
 import 'package:mongo_dart/src/database/message/additional/payload.dart';
 import 'package:mongo_dart/src/database/message/additional/section.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'dart:async';
 import 'package:test/test.dart';
 

--- a/test/mongo_dart_query_test.dart
+++ b/test/mongo_dart_query_test.dart
@@ -6,14 +6,12 @@ import 'package:mongo_dart_query/mongo_dart_query.dart';
 
 void testSelectorBuilderCreation() {
   var selector = where;
-  expect(selector.map is Map, isTrue);
   expect(selector.map, isEmpty);
 }
 
 void testSelectorBuilderOnObjectId() {
   var id = ObjectId();
   var selector = where.id(id);
-  expect(selector.map is Map, isTrue);
   expect(selector.map.length, greaterThan(0));
   expect(
       selector.map,

--- a/test/op_msg_bulk_operation_test.dart
+++ b/test/op_msg_bulk_operation_test.dart
@@ -1,13 +1,7 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/return_classes/abstract_write_result.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/bulk/ordered_bulk.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/bulk/unordered_bulk.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_many/delete_many_statement.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_one/delete_one_statement.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 import 'utils/insert_data.dart';
 
@@ -40,27 +34,14 @@ void main() async {
 
   group('Bulk Operations', () {
     var cannotRunTests = false;
-    var isReplicaSet = false;
     var isStandalone = false;
-    var isSharded = false;
-    var running4_4orGreater = false;
-    var running4_2orGreater = false;
 
     setUp(() async {
       await initializeDatabase();
       if (!db.masterConnection.serverCapabilities.supportsOpMsg) {
         cannotRunTests = true;
       }
-      var serverFcv = db.masterConnection.serverCapabilities.fcv ?? '0.0';
-      if (serverFcv.compareTo('4.4') != -1) {
-        running4_4orGreater = true;
-      }
-      if (serverFcv.compareTo('4.2') != -1) {
-        running4_2orGreater = true;
-      }
-      isReplicaSet = db.masterConnection.serverCapabilities.isReplicaSet;
       isStandalone = db.masterConnection.serverCapabilities.isStandalone;
-      isSharded = db.masterConnection.serverCapabilities.isShardedCluster;
     });
 
     tearDown(() async {

--- a/test/op_msg_collection_test.dart
+++ b/test/op_msg_collection_test.dart
@@ -1,12 +1,8 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/administration_commands/create_command/create_command.dart';
 import 'package:mongo_dart/src/database/commands/administration_commands/create_command/create_options.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_options.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:rational/rational.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 const dbName = 'test-mongo-dart';
 const dbAddress = '127.0.0.1';

--- a/test/op_msg_commands_test.dart
+++ b/test/op_msg_commands_test.dart
@@ -4,15 +4,9 @@ import 'package:mongo_dart/src/database/commands/administration_commands/get_par
 import 'package:mongo_dart/src/database/commands/administration_commands/kill_cursors_command/kill_cursors_command.dart';
 import 'package:mongo_dart/src/database/commands/administration_commands/get_all_parameters_command/get_all_parameters_command.dart';
 
-import 'package:mongo_dart/src/database/commands/diagnostic_commands/server_status_command/server_status_command.dart';
-import 'package:mongo_dart/src/database/commands/diagnostic_commands/server_status_command/server_status_options.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_command.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_options.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 const dbName = 'test-mongo-dart';
 const dbAddress = '127.0.0.1';

--- a/test/op_msg_read_operation_test.dart
+++ b/test/op_msg_read_operation_test.dart
@@ -2,21 +2,14 @@
 
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/cursor/modern_cursor.dart';
-import 'package:mongo_dart/src/database/commands/administration_commands/wrapper/create_collection/create_collection_options.dart';
-import 'package:mongo_dart/src/database/commands/aggreagation_commands/aggregate/aggregate_operation.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/count/count_operation.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/count/count_options.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/distinct/distinct_operation.dart';
 import 'package:mongo_dart/src/database/commands/aggreagation_commands/distinct/distinct_options.dart';
-import 'package:mongo_dart/src/database/commands/aggreagation_commands/wrapper/change_stream/change_stream_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_operation/find_options.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/get_more_command/get_more_command.dart';
 import 'package:mongo_dart/src/database/commands/parameters/read_concern.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:rational/rational.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 import 'utils/insert_data.dart';
 
@@ -1014,12 +1007,10 @@ db.runCommand(
     var isStandalone = false;
     setUp(() async {
       await initializeDatabase();
-      if (db.masterConnection == null ||
-          !db.masterConnection.serverCapabilities.supportsOpMsg) {
+      if (!db.masterConnection.serverCapabilities.supportsOpMsg) {
         cannotRunTests = true;
       }
-      if (db.masterConnection != null &&
-          db.masterConnection.serverCapabilities.isStandalone) {
+      if (db.masterConnection.serverCapabilities.isStandalone) {
         isStandalone = true;
       }
     });
@@ -1341,7 +1332,6 @@ db.runCommand(
   group('Distinct', () {
     var cannotRunTests = false;
     var running3_6 = false;
-    var isReplicaSet = false;
     var isSharded = false;
     setUp(() async {
       await initializeDatabase();
@@ -1352,7 +1342,6 @@ db.runCommand(
       if (serverFcv.compareTo('3.6') == 0) {
         running3_6 = true;
       }
-      isReplicaSet = db.masterConnection.serverCapabilities.isReplicaSet;
       isSharded = db.masterConnection.serverCapabilities.isShardedCluster;
     });
 

--- a/test/op_msg_update_operation_test.dart
+++ b/test/op_msg_update_operation_test.dart
@@ -2,13 +2,8 @@ import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_operation.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_options.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/update_operation/update_statement.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/replace_one/replace_one_statement.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:mongo_dart/src/database/utils/update_document_check.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 import 'utils/insert_data.dart';
 
@@ -71,27 +66,18 @@ void main() async {
   });
 
   group('Update Operations', () {
-    var cannotRunTests = false;
-    var running4_4orGreater = false;
     var running4_2orGreater = false;
-
-    var isReplicaSet = false;
-    var isStandalone = false;
     var isSharded = false;
+
     setUp(() async {
       await initializeDatabase();
-      if (!db.masterConnection.serverCapabilities.supportsOpMsg) {
-        cannotRunTests = true;
-      }
+
       var serverFcv = db.masterConnection.serverCapabilities.fcv;
-      if (serverFcv?.compareTo('4.4') != -1) {
-        running4_4orGreater = true;
-      }
+
       if (serverFcv?.compareTo('4.2') != -1) {
         running4_2orGreater = true;
       }
-      isReplicaSet = db.masterConnection.serverCapabilities.isReplicaSet;
-      isStandalone = db.masterConnection.serverCapabilities.isStandalone;
+
       isSharded = db.masterConnection.serverCapabilities.isShardedCluster;
     });
 

--- a/test/op_msg_write_operation_test.dart
+++ b/test/op_msg_write_operation_test.dart
@@ -1,18 +1,8 @@
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:mongo_dart/src/database/message/mongo_modern_message.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_and_modify_operation/find_and_modify_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/find_and_modify_operation/find_and_modify_options.dart';
 import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/return_classes/abstract_write_result.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_many/delete_many_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_many/delete_many_options.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_many/delete_many_statement.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_one/delete_one_operation.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/wrapper/delete_one/delete_one_statement.dart';
-import 'package:mongo_dart/src/database/commands/parameters/collation_options.dart';
-import 'package:mongo_dart/src/database/utils/map_keys.dart';
 import 'package:rational/rational.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart';
 
 import 'utils/insert_data.dart';
 
@@ -48,9 +38,7 @@ void main() async {
     var running4_4orGreater = false;
     var running4_2orGreater = false;
 
-    var isReplicaSet = false;
     var isStandalone = false;
-    var isSharded = false;
     setUp(() async {
       await initializeDatabase();
       if (!db.masterConnection.serverCapabilities.supportsOpMsg) {
@@ -63,9 +51,7 @@ void main() async {
       if (serverFcv.compareTo('4.2') != -1) {
         running4_2orGreater = true;
       }
-      isReplicaSet = db.masterConnection.serverCapabilities.isReplicaSet;
       isStandalone = db.masterConnection.serverCapabilities.isStandalone;
-      isSharded = db.masterConnection.serverCapabilities.isShardedCluster;
     });
 
     tearDown(() async {

--- a/test/ssl_connection_test.dart
+++ b/test/ssl_connection_test.dart
@@ -119,9 +119,9 @@ void main() {
           'mongodb+srv://dbAtlas:pwd@cluster0.xopug.mongodb.net/'
           'test?authMechanism=SCRAM-SHA-256&retryWrites=true&w=majority');
       await db.open();
-      var coll = db.collection('test-insert');
-      var result =
-          await coll.insertOne({'solved': true, 'autoinit': 'delayed'});
+      // var coll = db.collection('test-insert');
+      // var result =
+      //     await coll.insertOne({'solved': true, 'autoinit': 'delayed'});
       // Todo update test
       // print(result['ops'].first);
       /* Todo update

--- a/test/utils/insert_data.dart
+++ b/test/utils/insert_data.dart
@@ -1,5 +1,4 @@
 import 'package:mongo_dart/mongo_dart.dart';
-import 'package:mongo_dart/src/database/commands/query_and_write_operation_commands/return_classes/bulk_write_result.dart';
 
 /// For op_msg
 Future<BulkWriteResult> insertOrders(DbCollection collection) async {

--- a/test/uuid_test.dart
+++ b/test/uuid_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid.dart' hide UuidValue;
 
 const dbName = 'test';
 const dbAddress = '127.0.0.1';


### PR DESCRIPTION
Currently the package has 110 pub points out of 130 at pub.dev.  The reason for that are 100+ static analysis warnings (analyzed Pana 0.21.10, Dart 2.16.1).

I've fixed all those warnings with SDK version 2.16.2. There were plenty of reduntant imports, unreferenced variables, features depreicated in the context of null-safety. There're currently just 2 warnings which are TODO's. Tests are passing.

Hopefuly this cleanup makes the package better in terms of PUB score on pub.dev.