### PR TITLE
Upgraded bson dependency from ^1.0.4 to ^2.0.0 and rational dependenc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Recent change notes
 
+## 0.7.5
+
+- Upgraded bson dependency from ^1.0.4 to ^2.0.0 and rational dependency from ^1.2.1 to ^2.2.0
+
 ## 0.7.4+2
 
 Now using Lints instead of Pedantic

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mongo_dart
-version: 0.7.4+2
+version: 0.7.5
 description: MongoDB driver, implemented in pure Dart. All CRUD operations, aggregation pipeline and more!
 homepage: https://github.com/mongo-dart/mongo_dart
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  bson: ^1.0.4
+  bson: ^2.0.0
   crypto: ^3.0.0
   logging: ^1.0.0
   mongo_dart_query: ^1.0.0
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.8.0
   pool: ^1.5.0
   basic_utils: ^4.2.0
-  rational: ^1.2.1
+  rational: ^2.2.0
   uuid: ^3.0.0
   sasl_scram: ^0.1.0
   vy_string_utils: ^0.4.0
@@ -27,3 +27,7 @@ dev_dependencies:
 false_secrets:
  - /test/certificates_for_testing/*.key
  - /test/certificates_for_testing/*.pem
+
+# dependency_overrides:
+#   bson:
+#     path: ../bson


### PR DESCRIPTION
mongo_dart is the only dependency that is preventing me from upgrading my projects rational dependency to 2.2.0. This PR fixes that issue.