### PR TITLE
Throw exception containing error message instead of Euler's constant

### DIFF
--- a/lib/src/network/connection.dart
+++ b/lib/src/network/connection.dart
@@ -188,7 +188,7 @@ class Connection {
     // ignore: unawaited_futures
     _socket.done.catchError((error) {
       _log.info('Socket error $error');
-      throw ConnectionException('Socket error: $e');
+      throw ConnectionException('Socket error: $error');
     });
     socket = _socket;
 


### PR DESCRIPTION
At first, I was a bit confused when <kbd>mongo_dart</kbd>'s error message pointed me to Euler's constant:

```log
MongoDB ConnectionException: Socket error: 2.718281828459045
#0      Connection.connect.<anonymous closure>
package:mongo_dart/…/network/connection.dart:191
#1      _RootZone.runUnary (dart:async/zone.dart:1685:54)
#2      _FutureListener.handleError (dart:async/future_impl.dart:177:22)
#3      Future._propagateToListeners.handleError (dart:async/future_impl.dart:778:47)
#4      Future._propagateToListeners (dart:async/future_impl.dart:799:13)
#5      Future._propagateToListeners (dart:async/future_impl.dart:691:9)
#6      Future._completeError (dart:async/future_impl.dart:609:5)
#7      Future._asyncCompleteError.<anonymous closure> (dart:async/future_impl.dart:665:7)
#8      _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
#9      _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
#10     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:122:13)
#11     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:193:5)
```

Looking into the code, the variable name used in the exception message referenced `dart:math`'s [`e`](https://api.dart.dev/stable/2.16.1/dart-math/e-constant.html) constant instead of the local `error` parameter.
