### PR TITLE
Feature/172 x509 support

### DIFF
--- a/lib/mongo_dart.dart
+++ b/lib/mongo_dart.dart
@@ -26,6 +26,7 @@ import 'package:bson/src/types/bson_map.dart';
 // ignore: implementation_imports
 import 'package:bson/src/types/bson_string.dart';
 import 'package:logging/logging.dart';
+import 'package:mongo_dart/src/auth/mongodb_x509_authenticator.dart';
 import 'package:uuid/uuid.dart';
 import 'package:mongo_dart/src/auth/scram_sha256_authenticator.dart';
 import 'package:mongo_dart/src/database/cursor/modern_cursor.dart';

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -1,5 +1,6 @@
 //part of mongo_dart;
 import 'package:mongo_dart/mongo_dart.dart' show Connection, Db, MongoDartError;
+import 'package:mongo_dart/src/auth/mongodb_x509_authenticator.dart';
 import 'package:sasl_scram/sasl_scram.dart' show UsernamePasswordCredential;
 
 import 'mongodb_cr_authenticator.dart';
@@ -7,7 +8,7 @@ import 'scram_sha1_authenticator.dart';
 import 'scram_sha256_authenticator.dart';
 
 // ignore: constant_identifier_names
-enum AuthenticationScheme { MONGODB_CR, SCRAM_SHA_1, SCRAM_SHA_256 }
+enum AuthenticationScheme { MONGODB_CR, SCRAM_SHA_1, SCRAM_SHA_256, X509 }
 
 abstract class Authenticator {
   Authenticator();
@@ -21,6 +22,8 @@ abstract class Authenticator {
         return ScramSha1Authenticator(credentials, db);
       case AuthenticationScheme.SCRAM_SHA_256:
         return ScramSha256Authenticator(credentials, db);
+      case AuthenticationScheme.X509:
+        return MongoDbX509Authenticator(credentials.username, db);
       default:
         throw MongoDartError("Authenticator wasn't specified");
     }

--- a/lib/src/auth/mongodb_x509_authenticator.dart
+++ b/lib/src/auth/mongodb_x509_authenticator.dart
@@ -1,0 +1,33 @@
+//part of mongo_dart;
+import 'package:mongo_dart/mongo_dart.dart'
+    show Connection, Db, DbCommand, MongoQueryMessage;
+import 'package:mongo_dart/src/auth/auth.dart';
+
+class MongoDbX509Authenticator extends Authenticator {
+  MongoDbX509Authenticator(this.username, this.db) : super();
+
+  static final String name = 'MONGODB-X509';
+
+  final Db db;
+  final String? username;
+
+  @override
+  Future authenticate(Connection connection) {
+    var command = createMongoDbX509AuthenticationCommand(db, username);
+    return db
+        .executeDbCommand(command, connection: connection)
+        .then((res) => res['ok'] == 1);
+  }
+
+  static DbCommand createMongoDbX509AuthenticationCommand(
+      Db db, String? username) {
+    var selector = {
+      'authenticate': 1,
+      'mechanism': name,
+      if (username != null && username.isNotEmpty) 'user': username,
+    };
+
+    return DbCommand(db.authSourceDb ?? db, DbCommand.SYSTEM_COMMAND_COLLECTION,
+        MongoQueryMessage.OPTS_NONE, 0, 0, selector, null);
+  }
+}

--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -392,6 +392,8 @@ class Db {
       _authenticationScheme = AuthenticationScheme.SCRAM_SHA_256;
     } else if (authenticationSchemeName == MongoDbCRAuthenticator.name) {
       _authenticationScheme = AuthenticationScheme.MONGODB_CR;
+    } else if (authenticationSchemeName == MongoDbX509Authenticator.name) {
+      _authenticationScheme = AuthenticationScheme.X509;
     } else {
       throw MongoDartError('Provided authentication scheme is '
           'not supported : $authenticationSchemeName');
@@ -727,7 +729,7 @@ class Db {
         .toList();
   }
 
-  Future<bool> authenticate(String userName, String password,
+  Future<bool> authenticate(String? userName, String? password,
       {Connection? connection}) async {
     var credential = UsernamePasswordCredential()
       ..username = userName

--- a/lib/src/network/connection_manager.dart
+++ b/lib/src/network/connection_manager.dart
@@ -90,12 +90,12 @@ class ConnectionManager {
         db._authenticationScheme = AuthenticationScheme.MONGODB_CR;
       }
     }
-    if (connection.serverConfig.userName == null) {
+    if (connection.serverConfig.isAuthenticated) {
       _log.fine(() => '$db: ${connection.serverConfig.hostUrl} connected');
     } else {
       try {
-        await db.authenticate(connection.serverConfig.userName!,
-            connection.serverConfig.password ?? '',
+        await db.authenticate(connection.serverConfig.userName,
+            connection.serverConfig.password,
             connection: connection);
         _log.fine(() => '$db: ${connection.serverConfig.hostUrl} connected');
       } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: MongoDB driver, implemented in pure Dart. All CRUD operations, aggr
 homepage: https://github.com/mongo-dart/mongo_dart
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   bson: ^5.0.0


### PR DESCRIPTION
## Related Issues

- https://github.com/mongo-dart/mongo_dart/issues/172

## Summary

This PR extends the Authenticator in the driver to authenticate via X.509.

It uses under the hood following connection: https://www.mongodb.com/docs/manual/tutorial/configure-x509-client-authentication/#authenticate-with-a-x-509-certificate

## Verifications

1. Atlas Sharded Cluster created in MongoDB Cloud
2. Created an X.509 PEM File (password protected) and downloaded the *.pem file.
3. Loaded *.pem file via Dart (was already supported):

```dart
var db = Db('mongodb+srv://mongo-dart.xxxxxxx.mongodb.net/?authSource=\$external&authMechanism=MONGODB-X509&retryWrites=true&w=majority');

await db.open(
  secure: true,
  tlsCertificateKeyFile: tlsFilePath,
  tlsCertificateKeyFilePassword: tlsFilePassword
);
```

Please keep in mind, that `authSource=\$external` is just a Dart escaped String for: `authSource=$external` ! If you setup your MongoDB URI via Environment variables keep in mind that the official Mongo setting for the AuthDB is: `$external`!

4. **Test on Windows Desktop** (example.dart):

```sh
Launching lib\main.dart on Windows in debug mode...
package:mongo_dart_web/main.dart:1
√  Built build\windows\x64\runner\Debug\web.exe.
Connecting to VM Service at ws://127.0.0.1:54980/X3MBcL2N9iY=/ws
flutter: ====================================================================
flutter: >> Adding Authors
flutter: {_id: ObjectId("65d5648f476690c4e2000000"), name: William Shakespeare, email: william@shakespeare.com, age: 587}
flutter: {_id: ObjectId("65d5648f476691c4e2000000"), name: Jorge Luis Borges, email: jorge@borges.com, age: 123}
flutter: ====================================================================
flutter: >> Authors ordered by age ascending
flutter: [Jorge Luis Borges]:[jorge@borges.com]:[123]
flutter: [William Shakespeare]:[william@shakespeare.com]:[587]
flutter: ====================================================================
flutter: >> Adding Users
flutter: {_id: ObjectId("65d5648f476692c4e2000000"), login: jdoe, name: John Doe, email: john@doe.com}
flutter: {_id: ObjectId("65d5648f476693c4e2000000"), login: lsmith, name: Lucy Smith, email: lucy@smith.com}
flutter: ====================================================================
flutter: >> Users ordered by login descending
flutter: [lsmith]:[Lucy Smith]:[lucy@smith.com]
flutter: [jdoe]:[John Doe]:[john@doe.com]
flutter: ====================================================================
flutter: >> Adding articles
flutter: ====================================================================
flutter: >> Articles ordered by title ascending
flutter: [Caminando por Buenos Aires]:[Las callecitas de Buenos Aires tienen ese no se que...]:[65d5648f476691c4e2000000]
flutter: [I must have seen thy face before]:[Thine eyes call me in a new way]:[65d5648f476690c4e2000000]
Reloaded 98 of 1661 libraries in 392ms (compile: 144 ms, reload: 102 ms, reassemble: 65 ms).
Application finished.
```

<img width="734" alt="image" src="https://github.com/mongo-dart/mongo_dart/assets/18512224/07c0dc27-8dce-41c4-8dcc-11bc967624e2">
