### PR TITLE
Change event improvements

### DIFF
--- a/lib/mongo_dart.dart
+++ b/lib/mongo_dart.dart
@@ -69,6 +69,7 @@ import 'src/database/commands/administration_commands/list_collections_command/l
 import 'src/database/commands/administration_commands/list_collections_command/list_collections_options.dart';
 import 'src/database/commands/administration_commands/listt_indexes_command/list_indexes_command.dart';
 import 'src/database/commands/administration_commands/listt_indexes_command/list_indexes_options.dart';
+import 'src/database/commands/aggregation_commands/aggregate/return_classes/change_event.dart';
 import 'src/database/commands/aggregation_commands/count/count_operation.dart';
 import 'src/database/commands/aggregation_commands/count/count_options.dart';
 import 'src/database/commands/aggregation_commands/count/count_result.dart';

--- a/lib/src/database/commands/aggregation_commands/aggregate/return_classes/change_event.dart
+++ b/lib/src/database/commands/aggregation_commands/aggregate/return_classes/change_event.dart
@@ -48,6 +48,13 @@ class ChangeEvent {
   /// the original update operation and the full document lookup.
   Map<String, dynamic>? fullDocument;
 
+  /// The document key of the document created or modified by the insert,
+  /// replace, delete, update operations (i.e. CRUD operations).
+  ///
+  /// This is useful in case of a delete operation and avoid to parse
+  /// serverResponse documentKey object directly.
+  Map<String, dynamic>? documentKey;
+
   /// The namespace (database and or collection) affected by the event.
   MongoDBNamespace? ns;
 
@@ -67,6 +74,7 @@ class ChangeEvent {
     }
     operationType = streamData[keyOperationType] as String?;
     fullDocument = streamData[keyFullDocument] as Map<String, dynamic>?;
+    documentKey = streamData[keyDocumentKey] as Map<String, dynamic>?;
     if (streamData[keyNs] != null) {
       ns = MongoDBNamespace.fromMap(
           <String, Object>{...streamData[keyNs] as Map});

--- a/lib/src/database/dbcollection.dart
+++ b/lib/src/database/dbcollection.dart
@@ -871,7 +871,7 @@ class DbCollection {
         rawOptions: rawOptions));
   }
 
-  Stream watch(Object pipeline,
+  Stream<ChangeEvent> watch(Object pipeline,
           {int? batchSize,
           String? hint,
           Map<String, Object>? hintDocument,

--- a/lib/src/database/utils/map_keys.dart
+++ b/lib/src/database/utils/map_keys.dart
@@ -75,6 +75,7 @@ const keyDeletes = 'deletes';
 const keyDeleteArgument = 'deletes';
 const keyDistinct = 'distinct';
 const keyDocuments = 'documents';
+const keyDocumentKey = 'documentKey';
 const keyDrop = 'drop';
 const keyDropDatabase = 'dropDatabase';
 const keyDropDuplicatedEntries = 'dropDups';


### PR DESCRIPTION
The PR does 3 things :

- Exposes `ChangeEvent` class to the public API.
- Explicits the return type of function `DbCollection.watch`.
- Adds the field `documentKey` to `ChangeEvent` class to avoid people having to parse `serverResponse` themselves in case of a delete event for example.

Thanks for your work and hope it will help someone else too.