### PR TITLE
Feat: Add onConnectionClosed callback for external reconnection handling

### DIFF
--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -471,14 +471,16 @@ class Db {
       bool tlsAllowInvalidCertificates = false,
       String? tlsCAFile,
       String? tlsCertificateKeyFile,
-      String? tlsCertificateKeyFilePassword}) async {
+      String? tlsCertificateKeyFilePassword,
+      Function? onConnectionClosed}) async {
     if (state == State.opening) {
       throw MongoDartError('Attempt to open db in state $state');
     }
 
     state = State.opening;
     _writeConcern = writeConcern;
-    _connectionManager = ConnectionManager(this);
+    _connectionManager =
+        ConnectionManager(this, onConnectionClosed: onConnectionClosed);
 
     for (var uri in _uriList) {
       _connectionManager!.addConnection(await _parseUri(uri,

--- a/lib/src/network/connection.dart
+++ b/lib/src/network/connection.dart
@@ -211,6 +211,7 @@ class Connection {
               if (!_closed) {
                 await _closeSocketOnError(socketError: e);
               }
+              _manager.onConnectionClosed?.call();
             },
             cancelOnError: true,
             // onDone is not called in any case after onData or OnError,
@@ -223,6 +224,7 @@ class Connection {
               if (!_closed) {
                 await _closeSocketOnError(socketError: noSecureRequestError);
               }
+              _manager.onConnectionClosed?.call();
             });
     connected = true;
     return true;

--- a/lib/src/network/connection_manager.dart
+++ b/lib/src/network/connection_manager.dart
@@ -7,8 +7,9 @@ class ConnectionManager {
   final replyCompleters = <int, Completer<MongoResponseMessage>>{};
   final sendQueue = Queue<MongoMessage>();
   Connection? _masterConnection;
+  final Function? onConnectionClosed;
 
-  ConnectionManager(this.db);
+  ConnectionManager(this.db, {this.onConnectionClosed});
 
   Connection? get masterConnection => _masterConnection;
 


### PR DESCRIPTION
This PR introduces a new optional callback, onConnectionClosed, on the Db class. This function is invoked when the underlying MongoDB connection's socket closes, specifically when the socket stream reports either an onError (e.g., network timeout, connection reset) or completes via onDone.

While the ideal long-term solution involves implementing a robust, internal auto-retry and command queue management system, this approach proves highly complex and time-consuming.

Rationale and Usage
This new callback provides an immediate, practical mechanism for client applications to handle unexpected connection loss gracefully:

Application Restart: The most common use case will be allowing application-level logic to trigger a full connection restart or application exit upon a fatal connection error.

State Management: It allows developers to reliably update application state when the connection status changes from active to closed.

By exposing this connection event, we empower library consumers to manage their own reconnection strategy and error handling without requiring complex changes within mongo_dart's core socket logic.

Example (Conceptual)
```
    final db = await Db.create(connectionString);
    await db.open(onConnectionClosed: () {
        print('Connection is closed, so let's restart the app');
    });
    await db.pingCommand();
    return db;
```
