### PR TITLE
Firestore Mongo compatibility: handle BSON SASL payloads and avoid fsync when disabled

### DIFF
--- a/lib/src/auth/sasl_authenticator.dart
+++ b/lib/src/auth/sasl_authenticator.dart
@@ -7,6 +7,7 @@ import 'package:sasl_scram/sasl_scram.dart'
     show SaslMechanism, UsernamePasswordCredential;
 import 'package:mongo_dart/mongo_dart.dart'
     show
+    BsonBinary,
         Connection,
         Db,
         DbCommand,
@@ -19,6 +20,14 @@ import 'package:mongo_dart/mongo_dart.dart'
         keyErrmsg,
         keyOk;
 import 'package:mongo_dart/src/auth/auth.dart';
+
+List<int> _decodePayload(dynamic payload) {
+  if (payload is BsonBinary) {
+    return payload.byteList;
+  }
+
+  return base64.decode(payload.toString());
+}
 
 abstract class SaslAuthenticator extends Authenticator {
   SaslAuthenticator(this.mechanism, this.db) : super();
@@ -51,8 +60,7 @@ abstract class SaslAuthenticator extends Authenticator {
       }
 
       var payload = result['payload'];
-
-      var payloadAsBytes = base64.decode(payload.toString());
+      var payloadAsBytes = _decodePayload(payload);
 
       if (mechanism.name == ScramSha1Authenticator.name) {
         currentStep = currentStep.transition(payloadAsBytes,
@@ -95,8 +103,7 @@ abstract class SaslAuthenticator extends Authenticator {
       }
 
       var payload = result['payload'];
-
-      var payloadAsBytes = base64.decode(payload.toString());
+      var payloadAsBytes = _decodePayload(payload);
 
       if (mechanism.name == ScramSha1Authenticator.name) {
         currentStep = currentStep.transition(payloadAsBytes,

--- a/lib/src/database/db.dart
+++ b/lib/src/database/db.dart
@@ -170,11 +170,11 @@ class WriteConcern {
       if (j) {
         ret[keyJ] = j;
       }
-      if (!j) {
+      if (!j && fsync) {
         if (serverStatus.isJournaled) {
-          ret[keyJ] = fsync;
+          ret[keyJ] = true;
         } else {
-          ret[keyFsync] = fsync;
+          ret[keyFsync] = true;
         }
       }
     }


### PR DESCRIPTION
Fixes #397

Issue #397 requested validation against a real load-balanced setup (Firestore Mongo-compatible endpoint). This PR provides that real-world validation using the latest mongo_dart release.

loadBalanced propagation works, but two additional compatibility issues appear in practice.

## Changes
- Accept BSON binary SASL payloads in authenticator (not only base64 string payloads).
- Do not emit fsync/j fallback flags in writeConcern when fsync is disabled.

## Why
In Firestore Mongo-compatible endpoints:
- SASL payload may arrive as BSON binary, causing `Invalid character` when decoded as base64 text.
- writeConcern fields related to fsync may be rejected when not explicitly requested.

## Validation
- Reproduced against Firestore Enterprise Mongo-compatible URI with `loadBalanced=true`, `tls=true`, `authMechanism=SCRAM-SHA-256`.
- Confirmed successful connection and CRUD flow after this patch.